### PR TITLE
refactor(RequestManager): change technique of renewing token

### DIFF
--- a/src/RequestManager.ts
+++ b/src/RequestManager.ts
@@ -23,7 +23,7 @@ export class RequestManager {
       .json();
   }
 
-  private async renewToken(): Promise<number> {
+  private async renewToken(): Promise<void> {
     const { access_token, expires_in } = await petitio('https://accounts.spotify.com/api/token', 'POST')
       .query('grant_type', 'client_credentials')
       .header('Authorization', this.authorization)

--- a/src/RequestManager.ts
+++ b/src/RequestManager.ts
@@ -13,8 +13,6 @@ export class RequestManager {
     this.authorization = `Basic ${Buffer.from(`${this.options.clientId}:${this.options.clientSecret}`).toString(
       'base64',
     )}`;
-
-    this.renewToken();
   }
 
   public async makeRequest<T>(endpoint: string, disableBaseUri: boolean = false): Promise<T> {
@@ -39,7 +37,7 @@ export class RequestManager {
   }
 
   private async renew(): Promise<void> {
-    if (this.nextRenew > Date.now()) {
+    if (this.nextRenew >= Date.now()) {
       await this.renewToken();
     }
   }


### PR DESCRIPTION
Instead of using setTimeout, use the same way of doing what i did for my gist: https://gist.github.com/null8626/9052505a12eec2463eb9940ef2b53578

It basically stores the time where it expires, and in every request, if the expire date exceeds the current time, then renew the token. This will save requests if the Spotify API isn't called in a while.